### PR TITLE
[DoctrineMigrations] Fix coding style change subscriber with doctrine/migrations v1.5.0

### DIFF
--- a/packages/DoctrineMigrations/src/EventSubscriber/ChangeCodingStandardEventSubscriber.php
+++ b/packages/DoctrineMigrations/src/EventSubscriber/ChangeCodingStandardEventSubscriber.php
@@ -65,7 +65,7 @@ final class ChangeCodingStandardEventSubscriber implements EventSubscriberInterf
 
 		$i = 0;
 		while ( ! file_exists($this->getMigrationFileByVersion($version)) && $i <= 10) {
-			$version--;
+			$version = (string) ($version - 1);
 			$i++;
 		}
 

--- a/packages/DoctrineMigrations/src/EventSubscriber/ChangeCodingStandardEventSubscriber.php
+++ b/packages/DoctrineMigrations/src/EventSubscriber/ChangeCodingStandardEventSubscriber.php
@@ -76,7 +76,9 @@ final class ChangeCodingStandardEventSubscriber implements EventSubscriberInterf
 
 	private function getCurrentVersionName() : string
 	{
-		return date('YmdHis');
+		return method_exists($this->configuration, 'generateVersionNumber') ?
+			$this->configuration->generateVersionNumber() :
+			date('YmdHis');
 	}
 
 

--- a/packages/DoctrineMigrations/tests/EventSubscriber/ChangeCodingStandardEventSubscriberTest.php
+++ b/packages/DoctrineMigrations/tests/EventSubscriber/ChangeCodingStandardEventSubscriberTest.php
@@ -13,6 +13,12 @@ use Symfony\Component\Console\Output\BufferedOutput;
 class ChangeCodingStandardEventSubscriberTest extends AbstractEventSubscriberTest
 {
 
+	/**
+	 * @var string
+	 */
+	private $timeZone;
+
+
 	protected function setUp()
 	{
 		parent::setUp();
@@ -20,6 +26,16 @@ class ChangeCodingStandardEventSubscriberTest extends AbstractEventSubscriberTes
 		/** @var Configuration $configuration */
 		$configuration = $this->container->getByType(Configuration::class);
 		$configuration->setMigrationsDirectory($this->getMigrationsDirectory());
+
+		$this->saveTimeZone();
+	}
+
+
+	protected function tearDown()
+	{
+		parent::tearDown();
+
+		$this->restoreTimeZone();
 	}
 
 
@@ -34,6 +50,13 @@ class ChangeCodingStandardEventSubscriberTest extends AbstractEventSubscriberTes
 	}
 
 
+	public function testDispatchingGenerateCommandWithTimezone()
+	{
+		$this->setTimeZone('Europe/Prague');
+		$this->testDispatchingGenerateCommand();
+	}
+
+
 	public function testDispatchingDiffCommand()
 	{
 		$input = new ArrayInput(['command' => 'migrations:diff']);
@@ -42,6 +65,13 @@ class ChangeCodingStandardEventSubscriberTest extends AbstractEventSubscriberTes
 		$result = $this->application->run($input, $output);
 		$this->assertSame(0, $result);
 		$this->assertCommandOutputAndMigrationCodeStyle($output->fetch());
+	}
+
+
+	public function testDispatchingDiffCommandWithTimezone()
+	{
+		$this->setTimeZone('Europe/Prague');
+		$this->testDispatchingDiffCommand();
 	}
 
 
@@ -78,6 +108,27 @@ class ChangeCodingStandardEventSubscriberTest extends AbstractEventSubscriberTes
 	{
 		preg_match('/"([^"]+)"/', $outputContent, $matches);
 		return $matches[1];
+	}
+
+
+	private function saveTimeZone()
+	{
+		$this->timeZone = ini_get('date.timezone');
+	}
+
+
+	private function restoreTimeZone()
+	{
+		ini_set('date.timezone', $this->timeZone);
+	}
+
+
+	/**
+	 * @param string $timeZone
+	 */
+	private function setTimeZone($timeZone)
+	{
+		ini_set('date.timezone', $timeZone);
 	}
 
 }


### PR DESCRIPTION
Hello!

In v1.5.0, doctrine/migrations changed default version numbers to UTC time. ChangeCodingStandardEventSubscriber uses date in local timezone, so it did not find the migration file.

I changed it so it uses method of Doctrine\DBAL\Migrations\Configuration\Configuration to get the current version (if available).